### PR TITLE
Fix build

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -11,14 +11,14 @@
 
 // modular headers :wink:
 #include "globals.h"
-#include "terminal/rawMode.h"
-#include "terminal/readKeypress.h"
 #include "terminal/die.h"
 #include "terminal/getWindowSize.h"
-#include "output/refreshScreen.h"
-#include "output/drawTilde.h"
-#include "input/processKeypress.h"
+#include "terminal/rawMode.h"
+#include "terminal/readKeypress.h"
 #include "buffer/mutableString.h"
+#include "output/drawTilde.h"
+#include "output/refreshScreen.h"
+#include "input/processKeypress.h"
 
 // driver functions
 int main()

--- a/output/refreshScreen.h
+++ b/output/refreshScreen.h
@@ -2,18 +2,18 @@ void editorRefreshScreen()
 {
     struct abuf ab = ABUF_INIT;
 
-    abAppend(ab, "\x1b[?25l", 6);
+    abAppend(&ab, "\x1b[?25l", 6);
     // abAppend(ab, "\x1b[2J", 4);
-    abAppend(ab, "\x1b[H", 3);
+    abAppend(&ab, "\x1b[H", 3);
 
     editorDrawRows(&ab);
 
     char buf[32];
-    
+
     snprintf(buf, sizeof(buf), "\x1b[%d;%dH", E.cy + 1, E.cx + 1);
-    
+
     abAppend(&ab, buf, strlen(buf));
-    abAppend(ab, "\x1b[?25h", 6);
+    abAppend(&ab, "\x1b[?25h", 6);
 
     write(STDOUT_FILENO, ab.b, ab.len);
     abFree(&ab);


### PR DESCRIPTION
Hey Sambhav,

Here are the errors I got when building on my machine:

```
cc editor.c -o editor -Wall -Wextra -pedantic -std=c99
In file included from editor.c:13:
./globals.h:20:5: warning: no newline at end of file [-Wnewline-eof]
} E;
    ^
In file included from editor.c:14:
./terminal/rawMode.h:6:9: warning: implicit declaration of function 'getWindowSize' is invalid in C99
      [-Wimplicit-function-declaration]
    if (getWindowSize(&E.screenRows, &E.screenColumns) == -1)
        ^
./terminal/rawMode.h:7:9: warning: implicit declaration of function 'die' is invalid in C99
      [-Wimplicit-function-declaration]
        die("getWindowSize");
        ^
./terminal/rawMode.h:53:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
In file included from editor.c:15:
./terminal/readKeypress.h:11:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
In file included from editor.c:16:
./terminal/die.h:1:6: error: conflicting types for 'die'
void die(const char *s)
     ^
./terminal/rawMode.h:7:9: note: previous implicit declaration is here
        die("getWindowSize");
        ^
In file included from editor.c:16:
./terminal/die.h:8:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
In file included from editor.c:17:
./terminal/getWindowSize.h:45:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
In file included from editor.c:18:
./output/refreshScreen.h:5:5: warning: implicit declaration of function 'abAppend' is invalid in C99
      [-Wimplicit-function-declaration]
    abAppend(ab, "\x1b[?25l", 6);
    ^
./output/refreshScreen.h:9:5: warning: implicit declaration of function 'editorDrawRows' is invalid in C99
      [-Wimplicit-function-declaration]
    editorDrawRows(&ab);
    ^
./output/refreshScreen.h:19:5: warning: implicit declaration of function 'abFree' is invalid in C99
      [-Wimplicit-function-declaration]
    abFree(&ab);
    ^
./output/refreshScreen.h:20:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
In file included from editor.c:19:
./output/drawTilde.h:1:6: error: conflicting types for 'editorDrawRows'
void editorDrawRows(struct abuf *ab)
     ^
./output/refreshScreen.h:9:5: note: previous implicit declaration is here
    editorDrawRows(&ab);
    ^
In file included from editor.c:19:
./output/drawTilde.h:39:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
In file included from editor.c:21:
./buffer/mutableString.h:1:6: error: conflicting types for 'abAppend'
void abAppend(struct abuf *ab, const char *s, int len)
     ^
./output/refreshScreen.h:5:5: note: previous implicit declaration is here
    abAppend(ab, "\x1b[?25l", 6);
    ^
In file included from editor.c:21:
./buffer/mutableString.h:10:6: error: conflicting types for 'abFree'
void abFree(struct abuf *ab)
     ^
./output/refreshScreen.h:19:5: note: previous implicit declaration is here
    abFree(&ab);
    ^
In file included from editor.c:21:
./buffer/mutableString.h:13:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
editor.c:34:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
14 warnings and 4 errors generated.
make: *** [editor] Error 1
```

There's basically 2 types of errors here. One is that your `#include`s need to be put in the right order, so that any `.h` file that uses a function in another `.h` file has to be included **after** the first one. In C you have to be careful to define functions in the right order.

The second type of error is just saying that you need to pass `&ab` to `abAppend()` instead of `ab`.

I got the build working, and included the fixes in this PR in case you want to take a look. 😄 